### PR TITLE
#27 - FontColors

### DIFF
--- a/src/main/java/de/nadirhelix/guestbook/GuestbookApplication.java
+++ b/src/main/java/de/nadirhelix/guestbook/GuestbookApplication.java
@@ -34,8 +34,6 @@ public class GuestbookApplication {
 				isDevMode = BooleanUtils.toBoolean(value);
 			}
 		}
-		SpringApplicationBuilder builder = new SpringApplicationBuilder(GuestbookApplication.class);
-		builder.headless(false).run(args);
 	}
 
 	private static void prepareHeadlessProperty() throws NoSuchFieldException {

--- a/src/main/java/de/nadirhelix/guestbook/config/ColorProvider.java
+++ b/src/main/java/de/nadirhelix/guestbook/config/ColorProvider.java
@@ -1,7 +1,9 @@
 package de.nadirhelix.guestbook.config;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
@@ -19,9 +21,21 @@ public class ColorProvider {
 				"#586987",
 				"#cdcdcd"
 			);
-
+	
+	private static final Map<String, String> FONT_COLORS = new HashMap<>();
+	
+	static {
+		FONT_COLORS.put("anthrazit", "#333");
+		FONT_COLORS.put("schnee", "#ddd");
+		FONT_COLORS.put("marine", "#338");
+	}
+	
 	public List<String> getColors() {
 		return COLORS;
+	}
+
+	public Map<String, String> getFontColors() {
+		return FONT_COLORS;
 	}
 
 	

--- a/src/main/java/de/nadirhelix/guestbook/controller/ConfigController.java
+++ b/src/main/java/de/nadirhelix/guestbook/controller/ConfigController.java
@@ -1,6 +1,7 @@
 package de.nadirhelix.guestbook.controller;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Resource;
 
@@ -57,6 +58,17 @@ public class ConfigController {
 	@GetMapping("/fonts")
 	public ResponseEntity<List<String>> getFonts() {
 		List<String> result = FontsProvider.getFonts();
+		return ResponseEntity.ok(result);
+	}
+
+	/**
+	 * Retrieves all available fonts.
+	 * 
+	 * @return {@link ResponseEntity} with font list
+	 */
+	@GetMapping("/fontcolors")
+	public ResponseEntity<Map<String, String>> getFontColors() {
+		Map<String, String> result = colorProvider.getFontColors();
 		return ResponseEntity.ok(result);
 	}
 	


### PR DESCRIPTION
- added fontcolors endpoint providing 3 font colors
- fixed startup problem

@malenkix the current output will look like:

```
{
    "schnee": "#ddd",
    "anthrazit": "#333",
    "marine": "#338"
}
```
